### PR TITLE
Pad the seconds place to two digits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ const drawRoundRect = (ctx: CanvasRenderingContext2D, x: number, y: number, w: n
 
 const formatTime = (time: number) => {
     const mins = Math.floor(time / 60);
-    const seconds = Math.floor(time - (mins * 60));
+    const seconds = Math.floor(time - (mins * 60)).toString().padStart(2,'0');
 
     return `${mins}:${seconds}`;
 }


### PR DESCRIPTION
This fixes issues like on https://cdn.discordapp.com/attachments/377988195423485962/791698370019852368/unknown.png, where it shows the time as 3:3